### PR TITLE
Make hoppers work with nodetimer-based furnaces.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -276,6 +276,7 @@ minetest.register_abm({
 						--print("no room for items")
 						return
 					end
+					minetest.get_node_timer({x=pos.x,y=pos.y-1,z=pos.z}):start(1.0)
 					stack:take_item(1)
 					inv:set_stack("main", i, stack)
 					--add to hopper or chest
@@ -447,6 +448,7 @@ minetest.register_abm({
 					inv:set_stack("main", i, stack)
 					--add to hopper or chest
 					--print("adding item")
+					minetest.get_node_timer(front):start(1.0)
 					inv2:add_item("fuel", item)
 					break
 					


### PR DESCRIPTION
Without starting the node timer, furnaces won't start working if hoppers are inserting items. We need to start the timer when we insert an item.

Note: I didn't actually test this, but the same fix was tested with pipeworks.
